### PR TITLE
fix: optimization getLocaleDate performances

### DIFF
--- a/src/components/task-list/task-list-table.tsx
+++ b/src/components/task-list/task-list-table.tsx
@@ -1,6 +1,17 @@
-import React from "react";
+import React, { useMemo } from "react";
 import styles from "./task-list-table.module.css";
 import { Task } from "../../types/public-types";
+
+const localeDateStringCache = {};
+const toLocaleDateStringFactory = (locale: string) => (date: Date, dateTimeOptions: Intl.DateTimeFormatOptions) => {
+  const key = date.toString();
+  let lds = localeDateStringCache[key];
+  if (!lds) {
+    lds = date.toLocaleDateString(locale, dateTimeOptions);
+    localeDateStringCache[key] = lds;
+  }
+  return lds;
+};
 
 export const TaskListTableDefault: React.FC<{
   rowHeight: number;
@@ -27,6 +38,8 @@ export const TaskListTableDefault: React.FC<{
     month: "long",
     day: "numeric",
   };
+  const toLocaleDateString = useMemo(() => toLocaleDateStringFactory(locale), [locale]);
+
   return (
     <div
       className={styles.taskListWrapper}
@@ -78,7 +91,7 @@ export const TaskListTableDefault: React.FC<{
                 maxWidth: rowWidth,
               }}
             >
-              &nbsp;{t.start.toLocaleDateString(locale, dateTimeOptions)}
+              &nbsp;{toLocaleDateString(t.start, dateTimeOptions)}
             </div>
             <div
               className={styles.taskListCell}
@@ -87,8 +100,7 @@ export const TaskListTableDefault: React.FC<{
                 maxWidth: rowWidth,
               }}
             >
-              &nbsp;
-              {t.end.toLocaleDateString(locale, dateTimeOptions)}
+              &nbsp;{toLocaleDateString(t.end, dateTimeOptions)}
             </div>
           </div>
         );
@@ -96,3 +108,4 @@ export const TaskListTableDefault: React.FC<{
     </div>
   );
 };
+

--- a/src/helpers/date-helper.ts
+++ b/src/helpers/date-helper.ts
@@ -1,4 +1,6 @@
 import { Task, ViewMode } from "../types/public-types";
+import DateTimeFormatOptions = Intl.DateTimeFormatOptions;
+import DateTimeFormat = Intl.DateTimeFormat;
 
 type DateHelperScales =
   | "year"
@@ -8,6 +10,18 @@ type DateHelperScales =
   | "minute"
   | "second"
   | "millisecond";
+
+const intlDTCache = {};
+const getCachedDateTimeFormat = (locString: string | string[], opts: DateTimeFormatOptions = {}): DateTimeFormat => {
+  const key = JSON.stringify([locString, opts]);
+  let dtf = intlDTCache[key];
+  if (!dtf) {
+    dtf = new Intl.DateTimeFormat(locString, opts);
+    intlDTCache[key] = dtf;
+  }
+  return dtf;
+};
+
 
 export const addToDate = (
   date: Date,
@@ -130,7 +144,7 @@ export const seedDates = (
 };
 
 export const getLocaleMonth = (date: Date, locale: string) => {
-  let bottomValue = new Intl.DateTimeFormat(locale, {
+  let bottomValue = getCachedDateTimeFormat(locale, {
     month: "long",
   }).format(date);
   bottomValue = bottomValue.replace(
@@ -173,3 +187,4 @@ export const getWeekNumberISO8601 = (date: Date) => {
 export const getDaysInMonth = (month: number, year: number) => {
   return new Date(year, month + 1, 0).getDate();
 };
+


### PR DESCRIPTION
## Reason

Open the Gantt chart component, found the fps drop, only 23fps minimum

![image](https://user-images.githubusercontent.com/36876080/129327175-12abd46d-9805-44e4-be8e-cec130877c00.png)


Through Chrome Devtools Performance analysis, it is found that `longtask` is more serious. And `toLocaleDateString` takes a long time:

![image](https://user-images.githubusercontent.com/36876080/129327934-de453423-4262-456b-a371-1098383c377a.png)

The `toLocaleDateString` function takes a long time
![image](https://user-images.githubusercontent.com/36876080/129328135-441b1b1f-b103-4e5b-bfde-33b236893f33.png)

the root cause seem to be that  instantiates a new Intl.DateTimeFormat every time toLocaleString is called, which has a relatively high cost. (https://github.com/moment/luxon/issues/352)

## Solution

Since there will only ever be a very limited number of formats, those format instances should be cached after creation. This reduces the runtime of toLocaleString cost by a factor of 10.

## Final Results

Through optimization, `FPS` has been improved by 10%. After the upgrade, the lowest reached 28fps
![image](https://user-images.githubusercontent.com/36876080/129329168-3406e5bd-dd04-4dbe-a830-83f1777c576c.png)


