### PR TITLE
fix: optimization calendar render performance

### DIFF
--- a/src/components/calendar/calendar.tsx
+++ b/src/components/calendar/calendar.tsx
@@ -2,6 +2,7 @@ import React, { ReactChild } from "react";
 import { ViewMode } from "../../types/public-types";
 import { TopPartOfCalendar } from "./top-part-of-calendar";
 import {
+  getCachedDateTimeFormat,
   getDaysInMonth,
   getLocaleMonth,
   getWeekNumberISO8601,
@@ -177,7 +178,7 @@ export const Calendar: React.FC<CalendarProps> = ({
     const dates = dateSetup.dates;
     for (let i = 0; i < dates.length; i++) {
       const date = dates[i];
-      const bottomValue = Intl.DateTimeFormat(locale, {
+      const bottomValue = getCachedDateTimeFormat(locale, {
         hour: "numeric",
       }).format(date);
 

--- a/src/helpers/date-helper.ts
+++ b/src/helpers/date-helper.ts
@@ -12,7 +12,7 @@ type DateHelperScales =
   | "millisecond";
 
 const intlDTCache = {};
-const getCachedDateTimeFormat = (locString: string | string[], opts: DateTimeFormatOptions = {}): DateTimeFormat => {
+export const getCachedDateTimeFormat = (locString: string | string[], opts: DateTimeFormatOptions = {}): DateTimeFormat => {
   const key = JSON.stringify([locString, opts]);
   let dtf = intlDTCache[key];
   if (!dtf) {


### PR DESCRIPTION
Seem like: https://github.com/MaTeMaTuK/gantt-task-react/pull/19.

But this optimization in the calendar (in demo quarter of day module and half of day module)