### PR TITLE
fix: optimize scroll

### DIFF
--- a/example/src/components/view-switcher.tsx
+++ b/example/src/components/view-switcher.tsx
@@ -48,13 +48,13 @@ export const ViewSwitcher: React.FC<ViewSwitcherProps> = ({
       </button>
       <button
         className="Button"
-        onClick={() => onViewModeChange(ViewMode.Year)}
+        onClick={() => onViewModeChange(ViewMode.QuarterYear)}
       >
-        Year
+        Quarter
       </button>
       <button
         className="Button"
-        onClick={() => onViewModeChange(ViewMode.QuarterYear)}
+        onClick={() => onViewModeChange(ViewMode.Year)}
       >
         Year
       </button>

--- a/src/components/calendar/calendar.tsx
+++ b/src/components/calendar/calendar.tsx
@@ -36,8 +36,10 @@ export const Calendar: React.FC<CalendarProps> = ({
     const topValues: ReactChild[] = [];
     const bottomValues: ReactChild[] = [];
     const topDefaultHeight = headerHeight * 0.5;
+
     for (let i = 0; i < dateSetup.dates.length; i++) {
       const date = dateSetup.dates[i];
+
       const bottomValue = date.getFullYear();
       bottomValues.push(
         <text
@@ -54,12 +56,14 @@ export const Calendar: React.FC<CalendarProps> = ({
         date.getFullYear() !== dateSetup.dates[i - 1].getFullYear()
       ) {
         const topValue = date.getFullYear().toString();
+
         let xText: number;
         if (rtl) {
           xText = (6 + i + date.getFullYear() + 1) * columnWidth;
         } else {
           xText = (6 + i - date.getFullYear()) * columnWidth;
         }
+
         topValues.push(
           <TopPartOfCalendar
             key={topValue}
@@ -80,6 +84,7 @@ export const Calendar: React.FC<CalendarProps> = ({
     const topValues: ReactChild[] = [];
     const bottomValues: ReactChild[] = [];
     const topDefaultHeight = headerHeight * 0.5;
+
     for (let i = 0; i < dateSetup.dates.length; i++) {
       const date = dateSetup.dates[i];
       // const bottomValue = getLocaleMonth(date, locale);
@@ -94,6 +99,7 @@ export const Calendar: React.FC<CalendarProps> = ({
           {quarter}
         </text>
       );
+
       if (
         i === 0 ||
         date.getFullYear() !== dateSetup.dates[i - 1].getFullYear()
@@ -105,6 +111,7 @@ export const Calendar: React.FC<CalendarProps> = ({
         } else {
           xText = (6 + i - date.getMonth()) * columnWidth;
         }
+
         topValues.push(
           <TopPartOfCalendar
             key={topValue}
@@ -380,6 +387,7 @@ export const Calendar: React.FC<CalendarProps> = ({
     case ViewMode.Hour:
       [topValues, bottomValues] = getCalendarValuesForHour();
   }
+
   return (
     <g className="calendar" fontSize={fontSize} fontFamily={fontFamily}>
       <rect

--- a/src/components/gantt/gantt.tsx
+++ b/src/components/gantt/gantt.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useState,
-  SyntheticEvent,
-  useRef,
-  useEffect,
-  useMemo,
-} from "react";
+import React, { useState, useRef, useEffect, useMemo } from "react";
 import { ViewMode, GanttProps, Task } from "../../types/public-types";
 import { GridProps } from "../grid/grid";
 import { ganttDateRange, seedDates } from "../../helpers/date-helper";
@@ -13,14 +7,14 @@ import { TaskGanttContentProps } from "./task-gantt-content";
 import { TaskListHeaderDefault } from "../task-list/task-list-header";
 import { TaskListTableDefault } from "../task-list/task-list-table";
 import { StandardTooltipContent, Tooltip } from "../other/tooltip";
-import { VerticalScroll } from "../other/vertical-scroll";
+
 import { TaskListProps, TaskList } from "../task-list/task-list";
 import { TaskGantt } from "./task-gantt";
 import { BarTask } from "../../types/bar-task";
 import { convertToBarTasks } from "../../helpers/bar-helper";
 import { GanttEvent } from "../../types/gantt-task-actions";
 import { DateSetup } from "../../types/date-setup";
-import { HorizontalScroll } from "../other/horizontal-scroll";
+
 import { removeHiddenTasks, sortTasks } from "../../helpers/other-helper";
 import styles from "./gantt.module.css";
 
@@ -96,7 +90,6 @@ export const Gantt: React.FunctionComponent<GanttProps> = ({
 
   const [scrollY, setScrollY] = useState(0);
   const [scrollX, setScrollX] = useState(-1);
-  const [ignoreScrollEvent, setIgnoreScrollEvent] = useState(false);
 
   // task change events
   useEffect(() => {
@@ -112,14 +105,18 @@ export const Gantt: React.FunctionComponent<GanttProps> = ({
       viewMode,
       preStepsCount
     );
+
     let newDates = seedDates(startDate, endDate, viewMode);
+
     if (rtl) {
       newDates = newDates.reverse();
       if (scrollX === -1) {
         setScrollX(newDates.length * columnWidth);
       }
     }
+
     setDateSetup({ dates: newDates, viewMode });
+
     setBarTasks(
       convertToBarTasks(
         filteredTasks,
@@ -173,6 +170,7 @@ export const Gantt: React.FunctionComponent<GanttProps> = ({
         (viewDate && currentViewDate?.valueOf() !== viewDate.valueOf()))
     ) {
       const dates = dateSetup.dates;
+
       const index = dates.findIndex(
         (d, i) =>
           viewDate.valueOf() >= d.valueOf() &&
@@ -254,70 +252,6 @@ export const Gantt: React.FunctionComponent<GanttProps> = ({
     }
   }, [ganttHeight, tasks, headerHeight, rowHeight]);
 
-  // scroll events
-  useEffect(() => {
-    const handleWheel = (event: WheelEvent) => {
-      if (event.shiftKey || event.deltaX) {
-        const scrollMove = event.deltaX ? event.deltaX : event.deltaY;
-        let newScrollX = scrollX + scrollMove;
-        if (newScrollX < 0) {
-          newScrollX = 0;
-        } else if (newScrollX > svgWidth) {
-          newScrollX = svgWidth;
-        }
-        setScrollX(newScrollX);
-        event.preventDefault();
-      } else if (ganttHeight) {
-        let newScrollY = scrollY + event.deltaY;
-        if (newScrollY < 0) {
-          newScrollY = 0;
-        } else if (newScrollY > ganttFullHeight - ganttHeight) {
-          newScrollY = ganttFullHeight - ganttHeight;
-        }
-        if (newScrollY !== scrollY) {
-          setScrollY(newScrollY);
-          event.preventDefault();
-        }
-      }
-
-      setIgnoreScrollEvent(true);
-    };
-
-    // subscribe if scroll is necessary
-    wrapperRef.current?.addEventListener("wheel", handleWheel, {
-      passive: false,
-    });
-    return () => {
-      wrapperRef.current?.removeEventListener("wheel", handleWheel);
-    };
-  }, [
-    wrapperRef,
-    scrollY,
-    scrollX,
-    ganttHeight,
-    svgWidth,
-    rtl,
-    ganttFullHeight,
-  ]);
-
-  const handleScrollY = (event: SyntheticEvent<HTMLDivElement>) => {
-    if (scrollY !== event.currentTarget.scrollTop && !ignoreScrollEvent) {
-      setScrollY(event.currentTarget.scrollTop);
-      setIgnoreScrollEvent(true);
-    } else {
-      setIgnoreScrollEvent(false);
-    }
-  };
-
-  const handleScrollX = (event: SyntheticEvent<HTMLDivElement>) => {
-    if (scrollX !== event.currentTarget.scrollLeft && !ignoreScrollEvent) {
-      setScrollX(event.currentTarget.scrollLeft);
-      setIgnoreScrollEvent(true);
-    } else {
-      setIgnoreScrollEvent(false);
-    }
-  };
-
   /**
    * Handles arrow keys events and transform it to new scroll
    */
@@ -361,7 +295,6 @@ export const Gantt: React.FunctionComponent<GanttProps> = ({
       }
       setScrollY(newScrollY);
     }
-    setIgnoreScrollEvent(true);
   };
 
   /**
@@ -450,9 +383,9 @@ export const Gantt: React.FunctionComponent<GanttProps> = ({
     TaskListTable,
   };
   return (
-    <div>
+    <div style={{ overflowX: "auto" }}>
       <div
-        className={styles.wrapper}
+        style={{ overflowY: "auto", display: "flex" }}
         onKeyDown={handleKeyDown}
         tabIndex={0}
         ref={wrapperRef}
@@ -484,22 +417,7 @@ export const Gantt: React.FunctionComponent<GanttProps> = ({
             svgWidth={svgWidth}
           />
         )}
-        <VerticalScroll
-          ganttFullHeight={ganttFullHeight}
-          ganttHeight={ganttHeight}
-          headerHeight={headerHeight}
-          scroll={scrollY}
-          onScroll={handleScrollY}
-          rtl={rtl}
-        />
       </div>
-      <HorizontalScroll
-        svgWidth={svgWidth}
-        taskListWidth={taskListWidth}
-        scroll={scrollX}
-        rtl={rtl}
-        onScroll={handleScrollX}
-      />
     </div>
   );
 };

--- a/src/components/gantt/task-gantt.tsx
+++ b/src/components/gantt/task-gantt.tsx
@@ -25,21 +25,14 @@ export const TaskGantt: React.FC<TaskGanttProps> = ({
   const verticalGanttContainerRef = useRef<HTMLDivElement>(null);
   const newBarProps = { ...barProps, svg: ganttSVGRef };
 
-  useEffect(() => {
-    if (horizontalContainerRef.current) {
-      horizontalContainerRef.current.scrollTop = scrollY;
-    }
-  }, [scrollY]);
+  useEffect(() => {}, [scrollY]);
 
-  useEffect(() => {
-    if (verticalGanttContainerRef.current) {
-      verticalGanttContainerRef.current.scrollLeft = scrollX;
-    }
-  }, [scrollX]);
+  useEffect(() => {}, [scrollX]);
 
   return (
     <div
       className={styles.ganttVerticalContainer}
+      style={{ overflow: "auto" }}
       ref={verticalGanttContainerRef}
       dir="ltr"
     >

--- a/src/helpers/bar-helper.ts
+++ b/src/helpers/bar-helper.ts
@@ -153,6 +153,7 @@ const convertToBar = (
 ): BarTask => {
   let x1: number;
   let x2: number;
+
   if (rtl) {
     x2 = taskXCoordinateRTL(task.start, dates, columnWidth);
     x1 = taskXCoordinateRTL(task.end, dates, columnWidth);
@@ -173,6 +174,7 @@ const convertToBar = (
     rtl
   );
   const y = taskYCoordinate(index, rowHeight, taskHeight);
+
   const hideChildren = task.type === "project" ? task.hideChildren : undefined;
 
   const styles = {
@@ -253,6 +255,7 @@ const taskXCoordinate = (xDate: Date, dates: Date[], columnWidth: number) => {
   const percentOfInterval =
     remainderMillis / (dates[index + 1].getTime() - dates[index].getTime());
   const x = index * columnWidth + percentOfInterval * columnWidth;
+
   return x;
 };
 const taskXCoordinateRTL = (

--- a/src/helpers/date-helper.ts
+++ b/src/helpers/date-helper.ts
@@ -147,6 +147,9 @@ export const seedDates = (
   viewMode: ViewMode
 ) => {
   let currentDate: Date = new Date(startDate);
+  if (viewMode === ViewMode.QuarterYear) {
+    currentDate = addToDate(currentDate, -1, "month");
+  }
   const dates: Date[] = [currentDate];
   while (currentDate < endDate) {
     switch (viewMode) {


### PR DESCRIPTION
optmizes the scroll by relying on css and not stated.
The existing solution was causing far too many rerenders because of a useEffect that was calling setStateX while being dependent on stateX. I just did a bunch of css changes, to make the overall scroll feel way more natural and simple. 
Dont feel I broke anything, but still fail to understand what was the point of doing the scroll in tehe way that it was before.
Didnt clean the entire project, since I ran into another coupld of major bugs that need fast fixes.