### PR TITLE
feat(calendar-view): add week prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ npm start
 | preStepsCount  | number  | Specifies empty space before the fist task                                                                  |
 | locale         | string  | Specifies the month name language. Able formats: ISO 639-2, Java Locale.                                    |
 | rtl            | boolean | Sets rtl mode.                                                                                              |
+| weekPrefix      | string  | Set the prefix of the week (Default 'W').                                                                                              |
 
 ### StylingOption
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gantt-task-react",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gantt-task-react",
-      "version": "0.3.8",
+      "version": "0.3.9",
       "license": "MIT",
       "devDependencies": {
         "@testing-library/jest-dom": "^5.16.4",

--- a/src/components/calendar/calendar.tsx
+++ b/src/components/calendar/calendar.tsx
@@ -14,6 +14,7 @@ import styles from "./calendar.module.css";
 export type CalendarProps = {
   dateSetup: DateSetup;
   locale: string;
+  weekPrefix: string;
   viewMode: ViewMode;
   rtl: boolean;
   headerHeight: number;
@@ -31,6 +32,7 @@ export const Calendar: React.FC<CalendarProps> = ({
   columnWidth,
   fontFamily,
   fontSize,
+  weekPrefix,
 }) => {
   const getCalendarValuesForYear = () => {
     const topValues: ReactChild[] = [];
@@ -179,7 +181,7 @@ export const Calendar: React.FC<CalendarProps> = ({
         topValue = `${getLocaleMonth(date, locale)}, ${date.getFullYear()}`;
       }
       // bottom
-      const bottomValue = `W${getWeekNumberISO8601(date)}`;
+      const bottomValue = `${weekPrefix}${getWeekNumberISO8601(date)}`;
 
       bottomValues.push(
         <text

--- a/src/components/gantt/gantt.tsx
+++ b/src/components/gantt/gantt.tsx
@@ -34,6 +34,7 @@ export const Gantt: React.FunctionComponent<GanttProps> = ({
   viewMode = ViewMode.Day,
   preStepsCount = 1,
   locale = "en-GB",
+  weekPrefix = 'W',
   barFill = 60,
   barCornerRadius = 3,
   barProgressColor = "#a3a3ff",
@@ -405,6 +406,7 @@ export const Gantt: React.FunctionComponent<GanttProps> = ({
     fontFamily,
     fontSize,
     rtl,
+    weekPrefix,
   };
   const barProps: TaskGanttContentProps = {
     tasks: barTasks,

--- a/src/types/public-types.ts
+++ b/src/types/public-types.ts
@@ -82,6 +82,7 @@ export interface DisplayOption {
    * Specifies the month name language. Able formats: ISO 639-2, Java Locale
    */
   locale?: string;
+  weekPrefix?: string;
   rtl?: boolean;
 }
 


### PR DESCRIPTION
Убрали хардокд префикса недели "W" и добавили свойства для установки необходимого префикса `weekPrefix={'Week'}`